### PR TITLE
Question: allow encoding on non-finite numbers

### DIFF
--- a/browser/encode.js
+++ b/browser/encode.js
@@ -82,14 +82,10 @@ function _encode(bytes, defers, value) {
     return size + length;
   }
   if (type === 'number') {
-    if (!isFinite(value)) {
-      throw new Error('Number is not finite');
-    }
-
     // TODO: encode to float 32?
 
     // float 64
-    if (Math.floor(value) !== value) {
+    if (Math.floor(value) !== value || !isFinite(value)) {
       bytes.push(0xcb);
       defers.push({ float: value, length: 8, offset: bytes.length });
       return 9;
@@ -296,7 +292,7 @@ function encode(value) {
       }
     } else if (defer.str) {
       utf8Write(view, offset, defer.str);
-    } else if (defer.float) {
+    } else if (defer.float !== undefined) {
       view.setFloat64(offset, defer.float);
     }
     deferIndex++;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -89,14 +89,10 @@ function _encode(bytes, defers, value) {
     return size + length;
   }
   if (type === 'number') {
-    if (!isFinite(value)) {
-      throw new Error('Number is not finite');
-    }
-
     // TODO: encode to float 32?
 
     // float 64
-    if (Math.floor(value) !== value) {
+    if (Math.floor(value) !== value || !isFinite(value)) {
       bytes.push(0xcb);
       defers.push({ float: value, length: 8, offset: bytes.length });
       return 9;
@@ -335,7 +331,7 @@ function encode(value) {
       } else {
         utf8Write(buf, offset, defer.str);
       }
-    } else if (defer.float) {
+    } else if (defer.float !== undefined) {
       buf.writeDoubleBE(defer.float, offset);
     } else if (defer.arraybuffer) {
       var arr = new Uint8Array(defer.arraybuffer);

--- a/test/test.js
+++ b/test/test.js
@@ -122,6 +122,9 @@ describe('notepack', function () {
   it('float 64', function () {
     check(1.1, 'cb' + '3ff199999999999a');
     check(1234567891234567.5, 'cb' + '43118b54f26ebc1e');
+    check(Infinity, 'cb' + '7ff0000000000000');
+    check(-Infinity, 'cb' + 'fff0000000000000');
+    check(NaN, 'cb' + '7ff8000000000000');
   });
 
   it('uint 8', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -291,4 +291,11 @@ describe('notepack', function () {
 
     expect(notepack.decode(notepack.encode(fixture))).to.deep.equal(fixture);
   });
+
+  [NaN, Infinity, -Infinity].forEach( function (value) {
+    it(value.toString(), function () {
+      expect(notepack.decode(notepack.encode(value))).to.equal(null);
+    });
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -295,10 +295,15 @@ describe('notepack', function () {
     expect(notepack.decode(notepack.encode(fixture))).to.deep.equal(fixture);
   });
 
-  [NaN, Infinity, -Infinity].forEach( function (value) {
-    it(value.toString(), function () {
-      expect(notepack.decode(notepack.encode(value))).to.equal(null);
-    });
+  it('Infinity', function () {
+    expect(notepack.decode(notepack.encode(Infinity))).to.equal(Infinity);
   });
 
+  it('-Infinity', function () {
+    expect(notepack.decode(notepack.encode(-Infinity))).to.equal(-Infinity);
+  });
+
+  it('NaN', function () {
+    expect(notepack.decode(notepack.encode(NaN))).to.be.nan;
+  });
 });


### PR DESCRIPTION
I have a Socket.IO app using [socket.io-redis](/socketio/socket.io-redis) that is crashing intermittently due to notepack throwing an encoding error:

```
Error: Number is not finite
    at _encode (./node_modules/notepack.io/lib/encode.js:93:13)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
    at _encode (./node_modules/notepack.io/lib/encode.js:286:15)
```

I haven't been able to track down the origin of the socket.io emits that have one of these values but it seems a little extreme to crash Socket.IO when a client potentially emits `NaN`, `Infinity`, or `-Infinity` somewhere in the emit values.

My remedy is to run a patched version of notepack that encodes these to null values in the meantime. I'm not sure what the best approach is for a correct solution moving forward.
