### PR TITLE
fix encoding for non-finite numbers

### DIFF
--- a/browser/encode.js
+++ b/browser/encode.js
@@ -82,14 +82,10 @@ function _encode(bytes, defers, value) {
     return size + length;
   }
   if (type === 'number') {
-    if (!isFinite(value)) {
-      throw new Error('Number is not finite');
-    }
-
     // TODO: encode to float 32?
 
     // float 64
-    if (Math.floor(value) !== value) {
+    if (Math.floor(value) !== value || !isFinite(value)) {
       bytes.push(0xcb);
       defers.push({ float: value, length: 8, offset: bytes.length });
       return 9;
@@ -296,7 +292,7 @@ function encode(value) {
       }
     } else if (defer.str) {
       utf8Write(view, offset, defer.str);
-    } else if (defer.float) {
+    } else if (defer.float !== undefined) {
       view.setFloat64(offset, defer.float);
     }
     deferIndex++;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -89,14 +89,10 @@ function _encode(bytes, defers, value) {
     return size + length;
   }
   if (type === 'number') {
-    if (!isFinite(value)) {
-      throw new Error('Number is not finite');
-    }
-
     // TODO: encode to float 32?
 
     // float 64
-    if (Math.floor(value) !== value) {
+    if (Math.floor(value) !== value || !isFinite(value)) {
       bytes.push(0xcb);
       defers.push({ float: value, length: 8, offset: bytes.length });
       return 9;
@@ -335,7 +331,7 @@ function encode(value) {
       } else {
         utf8Write(buf, offset, defer.str);
       }
-    } else if (defer.float) {
+    } else if (defer.float !== undefined) {
       buf.writeDoubleBE(defer.float, offset);
     } else if (defer.arraybuffer) {
       var arr = new Uint8Array(defer.arraybuffer);

--- a/test/test.js
+++ b/test/test.js
@@ -122,6 +122,9 @@ describe('notepack', function () {
   it('float 64', function () {
     check(1.1, 'cb' + '3ff199999999999a');
     check(1234567891234567.5, 'cb' + '43118b54f26ebc1e');
+    check(Infinity, 'cb' + '7ff0000000000000');
+    check(-Infinity, 'cb' + 'fff0000000000000');
+    check(NaN, 'cb' + '7ff8000000000000');
   });
 
   it('uint 8', function () {


### PR DESCRIPTION
New format (instead of throwing an error):

```
NaN: <Buffer cb 7f f8 00 00 00 00 00 00>
Infinity: <Buffer cb 7f f0 00 00 00 00 00 00>
-Infinity: <Buffer cb ff f0 00 00 00 00 00 00>
```
Note: compatible with `msgpack-lite`