### PR TITLE
Preserve the offset and length when creating a DataView from an ArrayBuffer view

### DIFF
--- a/browser/decode.js
+++ b/browser/decode.js
@@ -4,12 +4,13 @@ function Decoder(buffer) {
   this.offset = 0;
   if (buffer instanceof ArrayBuffer) {
     this.buffer = buffer;
+    this.view = new DataView(this.buffer);
   } else if (ArrayBuffer.isView(buffer)) {
     this.buffer = buffer.buffer;
+    this.view = new DataView(this.buffer, buffer.byteOffset, buffer.byteLength);
   } else {
     throw new Error('Invalid argument');
   }
-  this.view = new DataView(buffer);
 }
 
 function utf8Read(view, offset, length) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var notepack = require('../');
+var notepackBrowser = { encode : require('../browser/encode.js'),
+                        decode : require('../browser/decode.js') };
 
 function array(length) {
   var arr = new Array(length);
@@ -306,5 +308,25 @@ describe('notepack', function () {
     var fixture = require('./fixtures/10000.json');
 
     expect(notepack.decode(notepack.encode(fixture))).to.deep.equal(fixture);
+  });
+});
+
+describe('notepack browser', function() {
+  it('ArrayBuffer view', function() {
+    expect(notepackBrowser.decode(Uint8Array.from([ 0x93, 1, 2, 3 ]))).to.deep.equal([ 1, 2, 3 ]);
+  });
+
+  it('offset ArrayBuffer view', function() {
+    var buffer = new ArrayBuffer(14);
+    var view = new Uint8Array(buffer);
+
+    // Fill with junk before setting the encoded data
+    view.fill(0xFF);
+
+    // Put the encoded data somewhere in the middle of the buffer
+    view.set([ 0x93, 1, 2, 3 ], 4);
+
+    expect(notepackBrowser.decode(new Uint8Array(buffer, 4, 4))).to.deep.equal([ 1, 2, 3 ]);
+    expect(notepackBrowser.decode(new Uint16Array(buffer, 4, 2))).to.deep.equal([ 1, 2, 3 ]);
   });
 });


### PR DESCRIPTION
Fixes an issue where a view passed to the browser decoder's constructor will start reading the entire underlying ArrayBuffer instead of the portion that the view references.

This also fixes darrachequesne/notepack#10.