### PR TITLE
remove the unsafe integer check

### DIFF
--- a/browser/encode.js
+++ b/browser/encode.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
-
 function utf8Write(view, offset, str) {
   var c = 0;
   for (var i = 0, l = str.length; i < l; i++) {
@@ -89,10 +87,6 @@ function _encode(bytes, defers, value) {
       bytes.push(0xcb);
       defers.push({ float: value, length: 8, offset: bytes.length });
       return 9;
-    }
-
-    if (Math.abs(value) > MAX_SAFE_INTEGER) {
-      throw new Error('Integer is unsafe');
     }
 
     if (value >= 0) {

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 var MICRO_OPT_LEN = 32;
 
 // Faster for short strings than buffer.write
@@ -96,10 +95,6 @@ function _encode(bytes, defers, value) {
       bytes.push(0xcb);
       defers.push({ float: value, length: 8, offset: bytes.length });
       return 9;
-    }
-
-    if (Math.abs(value) > MAX_SAFE_INTEGER) {
-      throw new Error('Integer is unsafe');
     }
 
     if (value >= 0) {

--- a/test/test.js
+++ b/test/test.js
@@ -147,6 +147,9 @@ describe('notepack', function () {
   it('uint 64', function () {
     check(4294967296, 'cf0000000100000000');
     check(Math.pow(2, 53) - 1, 'cf001fffffffffffff');
+    // unsafe unsigned integer
+    check(Math.pow(2, 63), 'cf8000000000000000');
+    check(Math.pow(2, 63) + 1024, 'cf8000000000000000');
   });
 
   // NOTE: We'll always encode a positive number as a uint, but we should be
@@ -197,6 +200,9 @@ describe('notepack', function () {
     check(-7840340234323423, 'd3ffe42540896a3a21');
     // Minimum safe signed integer
     check(-Math.pow(2, 53) + 1, 'd3ffe0000000000001');
+    // unsafe signed integer
+    check(-Math.pow(2, 63), 'd38000000000000000');
+    check(-Math.pow(2, 63) - 1024, 'd38000000000000000');
   });
 
   it('fixext 1 / undefined', function () {


### PR DESCRIPTION
That check caused 'Integer is unsafe' errors when integers above (2^53 - 1) were encoded.

By the JSON specification, a Number is not limited in size, and that behaviour differed from the
other implementations like msgpack-lite.