### PR TITLE
add support for encoding int64-buffer

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -168,6 +168,20 @@ function _encode(bytes, defers, value) {
         return 1;
       }
 
+      // Uint64BE (https://github.com/kawanet/int64-buffer)
+      if (value._isUint64BE) {
+        value = value.toArray();
+        bytes.push(0xcf, ...value);
+        return 9;
+      }
+
+      // Int64BE (https://github.com/kawanet/int64-buffer)
+      if (value._isInt64BE) {
+        value = value.toArray();
+        bytes.push(0xd3, ...value);
+        return 9;
+      }
+
       if (Array.isArray(value)) {
         length = value.length;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -606,9 +606,9 @@
       "dev": true
     },
     "int64-buffer": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
-      "integrity": "sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E=",
+      "version": "0.99.1007",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.99.1007.tgz",
+      "integrity": "sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ==",
       "dev": true
     },
     "is-buffer": {
@@ -917,6 +917,12 @@
         "isarray": "^1.0.0"
       },
       "dependencies": {
+        "int64-buffer": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+          "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM=",
+          "dev": true
+        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "benchmark": "^2.1.2",
     "benchtable": "^0.1.0",
     "chai": "^3.5.0",
+    "int64-buffer": "^0.99.1007",
     "istanbul": "^0.4.5",
     "jshint": "^2.9.5",
     "mocha": "^3.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
 
 const notepack = require('../');
 const expect = require('chai').expect;
+const { Int64BE, Uint64BE } = require('int64-buffer');
 
 function array(length) {
   const arr = new Array(length);
@@ -153,6 +154,14 @@ describe('notepack', function () {
     check(Math.pow(2, 63) + 1024, 'cf8000000000000000');
   });
 
+  it('Uint64BE', function () {
+    checkEncode(new Uint64BE(4294967296), 'cf0000000100000000');
+    checkEncode(new Uint64BE(Math.pow(2, 53) - 1), 'cf001fffffffffffff');
+    // unsafe unsigned integer
+    checkEncode(new Uint64BE('18446744073709551615'), 'cfffffffffffffffff');
+    checkEncode(new Uint64BE('18446744073709551614'), 'cffffffffffffffffe');
+  });
+
   // NOTE: We'll always encode a positive number as a uint, but we should be
   // able to decode a positive int value
 
@@ -204,6 +213,21 @@ describe('notepack', function () {
     // unsafe signed integer
     check(-Math.pow(2, 63), 'd38000000000000000');
     check(-Math.pow(2, 63) - 1024, 'd38000000000000000');
+  });
+
+  it('Int64BE', function () {
+    checkEncode(new Int64BE(-2147483649), 'd3ffffffff7fffffff');
+    checkEncode(new Int64BE(-4294967297), 'd3fffffffeffffffff');
+    checkEncode(new Int64BE(-65437650001231), 'd3ffffc47c1c1de2b1');
+    checkEncode(new Int64BE(-1111111111111111), 'd3fffc0d7348ea8e39');
+    checkEncode(new Int64BE(-1532678092380345), 'd3fffa8e0992bfa747');
+    checkEncode(new Int64BE(-4503599627370496), 'd3fff0000000000000');
+    checkEncode(new Int64BE(-7840340234323423), 'd3ffe42540896a3a21');
+    // Minimum safe signed integer
+    checkEncode(new Int64BE(-Math.pow(2, 53) + 1), 'd3ffe0000000000001');
+    // unsafe signed integer
+    checkEncode(new Int64BE('-9223372036854775808'), 'd38000000000000000');
+    checkEncode(new Int64BE('-9223372036854775807'), 'd38000000000000001');
   });
 
   it('fixext 1 / undefined', function () {


### PR DESCRIPTION
This PR adds support for encoding actual 64bit integers instead of the maximum of 53bit supported natively by JavaScript. It does so by detecting that the value is an [int64-buffer](https://github.com/kawanet/int64-buffer) object. This is the same library that is used by [msgpack-lite](https://github.com/kawanet/msgpack-lite) to support 64bit integers.

Right now the change is limited to encoding since decoding would require adding `int64-buffer` as a dependency, which is a change that should likely be discussed, and might have to be added as a configuration option. I also only added support for big endian right now since decoding always uses big endian. This might be configured as well, but it might be enough to support only big endian.