### PR TITLE
perf(encode): use Number.isInteger

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -102,7 +102,7 @@ function _encode(bytes, defers, value) {
     case 'number':
       // TODO: encode to float 32?
 
-      if (Math.floor(value) !== value || !isFinite(value)) { // float 64
+      if (!Number.isInteger(value)) { // float 64
         bytes.push(0xcb);
         defers.push({ float: value, length: 8, offset: bytes.length });
         return 9;


### PR DESCRIPTION
`Number.isInteger` is a faster operation than flooring a value and then checking it with `isFinite`.

| | tiny │ small │ medium │ large |
|--|--|--|--|--|
| before │ 2,659,084 ops/sec │ 579,367 ops/sec │ 46,217 ops/sec │ 488 ops/sec   |
| after │ 2,784,261 ops/sec │ 618,960 ops/sec │ 46,302 ops/sec │ 480 ops/sec   |


