### PR TITLE
Fix float encoding for large numbers

### DIFF
--- a/browser/encode.js
+++ b/browser/encode.js
@@ -83,7 +83,7 @@ function _encode(bytes, defers, value) {
     // TODO: encode to float 32?
 
     // float 64
-    if (Math.floor(value) !== value || !isFinite(value)) {
+    if (value !== (value | 0) || !isFinite(value)) {
       bytes.push(0xcb);
       defers.push({ _float: value, _length: 8, _offset: bytes.length });
       return 9;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -102,7 +102,7 @@ function _encode(bytes, defers, value) {
     case 'number':
       // TODO: encode to float 32?
 
-      if (Math.floor(value) !== value || !isFinite(value)) { // float 64
+      if (value !== (value | 0) || !isFinite(value)) { // float 64
         bytes.push(0xcb);
         defers.push({ float: value, length: 8, offset: bytes.length });
         return 9;


### PR DESCRIPTION
Previously it would not encode large numbers such as 1e300 as a float