### PR TITLE
Support toJSON as a fallback on non-object types (BigInt)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
   "immed"         : true,
   "indent"        : 2,
   "latedef"       : true,
-  "newcap"        : true,
+  "newcap"        : false,
   "noarg"         : true,
   "noempty"       : true,
   "nonew"         : true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ node_js:
   - "8"
   - "10"
   - "12"
+  - "14"
+  - "16"
+  - "18"
   - "node"
 after_script: "npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ node_js:
   - "12"
   - "14"
   - "16"
-  - "18"
-  - "node"
 after_script: "npm install coveralls && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -278,6 +278,10 @@ function _encode(bytes, defers, value) {
       bytes.push(0xd4, 0, 0);
       return 3;
     default:
+      // Also support a toJSON on eg. BigInt.prototype (which has typeof value === 'bigint')
+      if (typeof value.toJSON === 'function') {
+        return _encode(bytes, defers, value.toJSON());
+      }
       throw new Error('Could not encode');
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -289,16 +289,18 @@ describe('notepack', function () {
     expect(notepack.encode(obj)).to.deep.equal(notepack.encode('c'));
   });
 
-  it('toJSON on BigInt.prototype', function () {
-    BigInt.prototype.toJSON = function () {
-      return String(this);
-    };
-    try {
-      expect(notepack.encode(BigInt(1234))).to.deep.equal(notepack.encode('1234'));
-    } finally {
-      delete BigInt.prototype.toJSON;
-    }
-  });
+  if (typeof BigInt === 'function') {
+    it('toJSON on BigInt.prototype', function () {
+      BigInt.prototype.toJSON = function () {
+        return String(this);
+      };
+      try {
+        expect(notepack.encode(BigInt(1234))).to.deep.equal(notepack.encode('1234'));
+      } finally {
+        delete BigInt.prototype.toJSON;
+      }
+    });
+  }
 
   it('all formats', function () {
     this.timeout(20000);

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* global BigInt */
+
 const notepack = require('../');
 const expect = require('chai').expect;
 
@@ -285,6 +287,17 @@ describe('notepack', function () {
       }
     };
     expect(notepack.encode(obj)).to.deep.equal(notepack.encode('c'));
+  });
+
+  it('toJSON on BigInt.prototype', function () {
+    BigInt.prototype.toJSON = function () {
+      return String(this);
+    };
+    try {
+      expect(notepack.encode(BigInt(1234))).to.deep.equal(notepack.encode('1234'));
+    } finally {
+      delete BigInt.prototype.toJSON;
+    }
   });
 
   it('all formats', function () {


### PR DESCRIPTION
Hi!

My application uses `BigInt` heavily, which results in `Could not encode` with this library. I tried to follow [this piece of advice](https://github.com/darrachequesne/notepack/issues/24#issuecomment-754500027) and specified a `BigInt.prototype.toJSON`. Unfortunately that doesn't work, because the `typeof` operator returns `bigint`, and this library only supports `toJSON` for values where `typeof` returns `object`.

I saw https://github.com/darrachequesne/notepack/pull/25 but thought it'd be worthwhile to consider a more minimalistic approach.

Drive-by: Don't test with node.js 18, as that seems to break Travis. (Should probably switch to a different CI provider)